### PR TITLE
Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -21,8 +21,9 @@ if (!rex::isBackend()) {
         $getParamSpracheId = "clang=";
         $getParams = parse_url($_SERVER['REQUEST_URI'], PHP_URL_QUERY);
         if (
-            strpos($getParams, $getParamArtikelId) === false
-            && strpos($getParams, $getParamSpracheId) === false
+           null === $getParams
+            || (strpos($getParams, $getParamArtikelId) === false
+            && strpos($getParams, $getParamSpracheId) === false)
         ) {
             $um = redaxo_url_rewrite\URLManager::getInstance();
 


### PR DESCRIPTION

Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in redaxo/src/addons/redaxo_url_rewrite/boot.php on line 23
Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in redaxo/src/addons/redaxo_url_rewrite/boot.php on line 24